### PR TITLE
Downgrade urllib3 after RequestsDependencyWarning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ IPy==1.0
 nose==1.3.7
 nosexcover==1.0.11
 requests==2.21.0
-urllib3==1.25.0
+urllib3==1.24.2
 pylint==2.3.1


### PR DESCRIPTION
Requests with current version 2.21.0 doesn't support urllib3 version 1.25.0 till now.